### PR TITLE
Add hourly beat schedule for monitor_prices

### DIFF
--- a/flights_project/celery.py
+++ b/flights_project/celery.py
@@ -1,8 +1,17 @@
 import os
 from celery import Celery
+from celery.schedules import crontab
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'flights_project.settings')
 
 app = Celery('flights_project')
 app.config_from_object('django.conf:settings', namespace='CELERY')
 app.autodiscover_tasks()
+
+# 毎時 monitor_prices タスクを実行
+app.conf.beat_schedule = {
+    'monitor-prices-every-hour': {
+        'task': 'monitor.tasks.monitor_prices',
+        'schedule': crontab(minute=0),
+    },
+}


### PR DESCRIPTION
## Summary
- update `flights_project/celery.py` to schedule `monitor_prices` every hour using Celery Beat

## Testing
- `python -m py_compile flights_project/celery.py`


------
https://chatgpt.com/codex/tasks/task_e_6884f8e5b0708329a59dc59a137e1135